### PR TITLE
Fix assistant message detection

### DIFF
--- a/count_user_inputs.py
+++ b/count_user_inputs.py
@@ -26,7 +26,7 @@ def count_messages_in_file(filepath):
 
                     if msg_type == 'user':
                         user_messages += 1
-                    elif msg_type == 'message' and data.get('message', {}).get('role') == 'assistant':
+                    elif msg_type == 'assistant':
                         assistant_messages += 1
                     elif msg_type == 'tool_use':
                         tool_uses += 1


### PR DESCRIPTION
## Summary
- Fixes assistant message type check from `type == 'message'` to `type == 'assistant'`
- The actual JSONL format uses `type == 'assistant'` for Claude's responses

## Problem
The script was showing `🤖 Claude responded: 0 messages` for all users because it was checking for the wrong message type.

## Test plan
- [ ] Run `python3 count_user_inputs.py`
- [ ] Verify Claude response count is now > 0

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)