### PR TITLE
Fix tool use counting

### DIFF
--- a/count_user_inputs.py
+++ b/count_user_inputs.py
@@ -28,8 +28,13 @@ def count_messages_in_file(filepath):
                         user_messages += 1
                     elif msg_type == 'message' and data.get('message', {}).get('role') == 'assistant':
                         assistant_messages += 1
-                    elif msg_type == 'tool_use':
-                        tool_uses += 1
+                    elif msg_type == 'assistant':
+                        # Tool uses are embedded in the content array of assistant messages
+                        content = data.get('message', {}).get('content', [])
+                        if isinstance(content, list):
+                            for item in content:
+                                if isinstance(item, dict) and item.get('type') == 'tool_use':
+                                    tool_uses += 1
 
                 except json.JSONDecodeError:
                     continue


### PR DESCRIPTION
## Summary
- Fixes tool use counting by looking inside assistant message content arrays
- Tool uses are embedded in `message.content[]`, not as top-level entries

## Problem
The script was showing `🔧 Tools used: 0 tool calls` for all users because it was checking for `type == 'tool_use'` at the top level of JSONL entries.

## Actual JSONL structure
```json
{
  "type": "assistant",
  "message": {
    "content": [
      {"type": "tool_use", "name": "Read", ...}
    ]
  }
}
```

## Test plan
- [ ] Run `python3 count_user_inputs.py`
- [ ] Verify tool call count is now > 0

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)