### PR TITLE
Use generic regex for project name cleanup

### DIFF
--- a/count_user_inputs.py
+++ b/count_user_inputs.py
@@ -6,6 +6,7 @@ This gives non-technical users a clearer understanding of engagement.
 
 import json
 import os
+import re
 from pathlib import Path
 from collections import defaultdict
 
@@ -67,10 +68,15 @@ def main():
             for key in ['user', 'assistant', 'tools', 'total']:
                 total_stats[key] += stats[key]
 
-            # Extract project name
-            project = jsonl_file.parent.name.replace('-Users-justinlai-Coding-', '')
-            if project == '-Users-justinlai-Coding':
-                project = 'Coding (root)'
+            # Extract project name from folder path
+            project = jsonl_file.parent.name
+            # Remove path prefixes like -Users-<username>-<folder>-
+            project = re.sub(r'^-Users-[^-]+-[^-]+-', '', project)
+            # Handle direct home subdirs like -Users-<username>-<project>
+            project = re.sub(r'^-Users-[^-]+-', '', project)
+            # Handle bare home directory
+            if re.match(r'^-Users-[^-]*$', project) or project == '':
+                project = 'Home'
 
             project_stats[project]['user'] += stats['user']
             project_stats[project]['assistant'] += stats['assistant']


### PR DESCRIPTION
## Summary
- Replace hardcoded username path with regex patterns
- Works for any user, not just the original author

## Problem
The code had hardcoded path replacements that only worked for one user:
```python
project = jsonl_file.parent.name.replace('-Users-justinlai-Coding-', '')
```

This caused project names to display with ugly path prefixes for other users.

## Solution
Use regex patterns that match any username and folder structure:
```python
project = re.sub(r'^-Users-[^-]+-[^-]+-', '', project)
project = re.sub(r'^-Users-[^-]+-', '', project)
```

## Before/After
| Before | After |
|--------|-------|
| `-Users-dave-Sites-myproject` | `myproject` |
| `-Users-dave-dotfiles` | `dotfiles` |
| `-Users-dave` | `Home` |

## Test plan
- [ ] Run `python3 count_user_inputs.py`
- [ ] Verify project names display without path prefixes

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)